### PR TITLE
[# 11] 게시판에서 카테고리에 따라 게시글 리스트를 볼 수 있다

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,15 +1,15 @@
 module.exports = {
-    stories: ["../src/**/*.stories.(ts|tsx|js|jsx)"],
-    addons: [
-        "@storybook/preset-create-react-app",
-        "@storybook/addon-knobs/register",
-        "@storybook/addon-actions",
-        "@storybook/addon-links",
-        {
-            name: "@storybook/addon-docs",
-            options: {
-                configureJSX: true
-            }
-        }
-    ]
+  stories: ["../src/**/*.stories.(ts|tsx|js|jsx)"],
+  addons: [
+    "@storybook/preset-create-react-app",
+    "@storybook/addon-knobs/register",
+    "@storybook/addon-actions",
+    "@storybook/addon-links",
+    {
+      name: "@storybook/addon-docs",
+      options: {
+        configureJSX: true
+      }
+    }
+  ]
 };

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,0 +1,1 @@
+import "!style-loader!css-loader!sass-loader!../src/index.scss";

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "@types/react": "^16.9.0",
         "@types/react-dom": "^16.9.0",
         "@types/react-router-dom": "^5.1.3",
+        "dayjs": "^1.8.23",
         "node-sass": "^4.13.1",
         "react": "^16.13.0",
         "react-dom": "^16.13.0",
@@ -42,10 +43,10 @@
         ]
     },
     "devDependencies": {
-        "@storybook/addon-knobs": "^5.3.17",
         "@storybook/addon-actions": "^5.3.17",
         "@storybook/addon-docs": "^5.3.17",
         "@storybook/addon-info": "^5.3.17",
+        "@storybook/addon-knobs": "^5.3.17",
         "@storybook/addon-links": "^5.3.17",
         "@storybook/addons": "^5.3.17",
         "@storybook/preset-create-react-app": "^2.0.0",

--- a/src/components/atoms/CommentCountIcon/comment.svg
+++ b/src/components/atoms/CommentCountIcon/comment.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 15.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="24px"
+	 height="24px" viewBox="0 0 24 24" style="enable-background:new 0 0 24 24;" xml:space="preserve">
+<g id="Icons" style="opacity:0.75;">
+	<g id="comment">
+		<path id="speech_bubble" style="fill-rule:evenodd;clip-rule:evenodd;" d="M15,6H9C7.343,6,6,7.344,6,9v4c0,1.656,1.343,3,3,3v3
+			l3-3h3c1.657,0,3-1.344,3-3V9C18,7.344,16.657,6,15,6z"/>
+	</g>
+</g>
+<g id="Guides" style="display:none;">
+</g>
+</svg>

--- a/src/components/atoms/CommentCountIcon/index.stories.tsx
+++ b/src/components/atoms/CommentCountIcon/index.stories.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { withKnobs, number } from "@storybook/addon-knobs";
+import CommentCountIcon from ".";
+
+export default {
+    title: "Atoms / CommentCountIcon",
+    decorators: [withKnobs],
+    component: CommentCountIcon
+};
+
+export const index = () => {
+    return <CommentCountIcon count={number("count", 12)} />;
+};

--- a/src/components/atoms/CommentCountIcon/index.tsx
+++ b/src/components/atoms/CommentCountIcon/index.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import commentIcon from "./comment.svg";
+import "./style.scss";
+
+const MAX_DISPLAY_NUM = 999;
+
+export interface CommentIcon {
+    /**
+     * 댓글 수
+     */
+    count: number;
+}
+
+export const CommentCountIcon = (props: CommentIcon) => {
+    const { count } = props;
+    const view = count > MAX_DISPLAY_NUM ? MAX_DISPLAY_NUM + "+" : count;
+
+    return (
+        <span className="comment_count_wrapper">
+            <img src={commentIcon} alt={"코멘트"} /> {view}
+        </span>
+    );
+};
+
+CommentCountIcon.defaultProps = {
+    count: 0
+};
+
+export default CommentCountIcon;

--- a/src/components/atoms/CommentCountIcon/style.scss
+++ b/src/components/atoms/CommentCountIcon/style.scss
@@ -1,0 +1,12 @@
+.comment_count_wrapper {
+    & {
+        line-height: 2.5rem;
+        text-align: center;
+        font-weight: lighter;
+        font-size: 0.8rem;
+    }
+
+    & > img {
+        vertical-align: middle;
+    }
+}

--- a/src/components/molecules/PostTable/index.stories.tsx
+++ b/src/components/molecules/PostTable/index.stories.tsx
@@ -29,17 +29,17 @@ export const index = () => {
             },
             {
                 no: 36,
-                title: "[회의록] 2020 동아리 홍보",
+                title: "리액트 쵝고 ㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎ",
                 commentCount: 12,
-                date: new Date("2020-03-22"),
+                date: new Date(),
                 writer: "이송열",
                 viewCount: 10
             },
             {
                 no: 35,
-                title: "리액트 쵝고 ㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎ",
+                title: "[회의록] 2020 동아리 홍보",
                 commentCount: 12,
-                date: "2020. 02. 29.",
+                date: new Date("2020-03-02"),
                 writer: "이송열",
                 viewCount: 10
             },

--- a/src/components/molecules/PostTable/index.stories.tsx
+++ b/src/components/molecules/PostTable/index.stories.tsx
@@ -1,0 +1,77 @@
+import React, { CSSProperties } from "react";
+import { withKnobs } from "@storybook/addon-knobs";
+import Table from ".";
+
+export default {
+    title: "Molecules / Table",
+    component: Table,
+    decorators: [withKnobs]
+};
+
+const WrapperStyle: CSSProperties = {
+    display: "flex",
+    flexDirection: "column",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: "5rem"
+};
+
+export const index = () => {
+    const props = {
+        posts: [
+            {
+                no: "공지",
+                title: "[회의록] 2020 동아리 홍보",
+                commentCount: 12,
+                date: new Date("2020-03-02"),
+                writer: "이송열",
+                viewCount: 10
+            },
+            {
+                no: 36,
+                title: "[회의록] 2020 동아리 홍보",
+                commentCount: 12,
+                date: new Date("2020-03-22"),
+                writer: "이송열",
+                viewCount: 10
+            },
+            {
+                no: 35,
+                title: "리액트 쵝고 ㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎㅎ",
+                commentCount: 12,
+                date: "2020. 02. 29.",
+                writer: "이송열",
+                viewCount: 10
+            },
+            {
+                no: 34,
+                title: "Team Crazy Perfomance !! ",
+                commentCount: 12,
+                date: "2019. 12. 29.",
+                writer: "이송열",
+                viewCount: 10
+            },
+            {
+                no: 33,
+                title: "김희라 짱짱 ",
+                commentCount: 12,
+                date: new Date("2020-03-02"),
+                writer: "이송열",
+                viewCount: 10
+            },
+            {
+                no: 33,
+                title: "글 제목이다",
+                commentCount: 12,
+                date: new Date("2020-03-02"),
+                writer: "이송열",
+                viewCount: 10
+            }
+        ]
+    };
+    return (
+        <div style={WrapperStyle}>
+            <Table {...props} />
+        </div>
+    );
+};

--- a/src/components/molecules/PostTable/index.tsx
+++ b/src/components/molecules/PostTable/index.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import "./style.scss";
+import CommentCountIcon from "../../atoms/CommentCountIcon";
+
+interface PostProps {
+    /**
+     * 게시글 번호
+     */
+    no: number | string;
+    /**
+     * 제목
+     */
+    title: string;
+    /**
+     * 댓글 수
+     */
+    commentCount: number;
+    /**
+     * 작성일자
+     */
+    date: Date | string;
+    /**
+     * 작성자
+     */
+    writer: string;
+    /**
+     * 조회수
+     */
+    viewCount: number;
+}
+
+export interface TableProps {
+    /**
+     * 테이블 칼럼 이름
+     */
+    columns: string[];
+    /**
+     * 포스트들
+     */
+    posts?: PostProps[];
+}
+
+const Columns = (props: PostProps) => {
+    const { no, title, commentCount, date, writer, viewCount } = props;
+    const className = no === "공지" ? "notice" : "";
+    const dateView = date instanceof Date ? date.toLocaleDateString() : date;
+    return (
+        <tr className={className}>
+            <td>{no}</td>
+            <td>{title}</td>
+            <td>
+                <CommentCountIcon count={commentCount} />
+            </td>
+            <td>{dateView}</td>
+            <td>{writer}</td>
+            <td>{viewCount}</td>
+        </tr>
+    );
+};
+
+const PostTable = (props: TableProps) => {
+    const { columns, posts = [] } = props;
+
+    return (
+        <table>
+            <tr>
+                {columns.map(col => (
+                    <th> {col} </th>
+                ))}
+            </tr>
+            {posts.map((post: PostProps) => (
+                <Columns {...post} />
+            ))}
+        </table>
+    );
+};
+
+PostTable.defaultProps = {
+    columns: ["번호", "제목", "", "날짜", "글쓴이", "조회수"],
+    posts: []
+};
+
+export default PostTable;

--- a/src/components/molecules/PostTable/index.tsx
+++ b/src/components/molecules/PostTable/index.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import "./style.scss";
 import CommentCountIcon from "../../atoms/CommentCountIcon";
+import { displayDate } from "../../../utils";
+
+const NOTICE_KO = "공지";
+const CLASSNAME_FOR_NOTICE = "notice";
 
 interface PostProps {
     /**
@@ -42,8 +46,9 @@ export interface TableProps {
 
 const Columns = (props: PostProps) => {
     const { no, title, commentCount, date, writer, viewCount } = props;
-    const className = no === "공지" ? "notice" : "";
-    const dateView = date instanceof Date ? date.toLocaleDateString() : date;
+    const className = no === NOTICE_KO ? CLASSNAME_FOR_NOTICE : "";
+    const dateView = displayDate(date);
+
     return (
         <tr className={className}>
             <td>{no}</td>

--- a/src/components/molecules/PostTable/style.scss
+++ b/src/components/molecules/PostTable/style.scss
@@ -1,0 +1,31 @@
+$table-line-color: #b7b7b9;
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    text-align: center;
+    font-size: 0.8rem;
+}
+
+th,
+td {
+    padding: 1rem 0.3rem;
+}
+
+th {
+    border-bottom: 2px solid #000;
+}
+
+td:nth-child(2) {
+    text-align: left;
+}
+
+tr {
+    & {
+        border-bottom: 1px solid $table-line-color;
+    }
+
+    &.notice {
+        font-weight: bold;
+    }
+}

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,4 +1,5 @@
 @import url("https://fonts.googleapis.com/css?family=Comfortaa&display=swap");
+@import url("https://fonts.googleapis.com/css?family=Noto+Sans+KR:300,400,700&display=swap");
 @import "./theme.scss";
 
 ::-webkit-scrollbar {
@@ -6,7 +7,7 @@
 }
 
 * {
-    font-family: "Comfortaa", cursive;
+    font-family: "Noto Sans KR", sans-serif;
     text-decoration: none;
     box-sizing: border-box;
     margin: 0;
@@ -29,6 +30,7 @@ header {
     left: 0;
     height: 14vh;
     min-height: 5rem;
+    font-family: "Comfortaa", cursive;
 }
 
 main {

--- a/src/utils/display-date.ts
+++ b/src/utils/display-date.ts
@@ -1,0 +1,11 @@
+import dayjs from "dayjs";
+import LocalizedFormat from "dayjs/plugin/localizedFormat";
+dayjs.extend(LocalizedFormat);
+
+export default (date: string | Date) => {
+    const postedAt = dayjs(date);
+
+    const format = dayjs().isSame(postedAt, "day") ? "LT" : "YY. MM. DD";
+
+    return postedAt.format(format);
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { default as displayDate } from "./display-date";

--- a/yarn.lock
+++ b/yarn.lock
@@ -5031,6 +5031,11 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
+dayjs@^1.8.23:
+  version "1.8.23"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.8.23.tgz#07b5a8e759c4d75ae07bdd0ad6977f851c01e510"
+  integrity sha512-NmYHMFONftoZbeOhVz6jfiXI4zSiPN6NoVWJgC0aZQfYVwzy/ZpESPHuCcI0B8BUMpSJQ08zenHDbofOLKq8hQ==
+
 de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"


### PR DESCRIPTION
### 간단 설명
[게시판 페이지](https://www.figma.com/file/wrbTnQInfRS4Fpm3FMMiMa/Team-Crazy-Performance-Copy?node-id=17%3A562)의 게시글 리스트를 테이블 형태로 노출하는 컴포넌트 UI 작성
  - 댓글 카운트 컴포넌트 UI 작성
  - 작성일자는 당일 작성 글일시  `5:37 PM` 
    이전 날짜 작성 글 일시 - `20. 03. 22`

### 스크린샷

#### 댓글 카운트 UI 
![image](https://user-images.githubusercontent.com/22452742/77297531-c50a5a00-6d2c-11ea-9a68-02de7cd48fc8.png)

#### 게시글 테이블
![image](https://user-images.githubusercontent.com/22452742/77297505-b9b72e80-6d2c-11ea-82d8-dc7019fe3c18.png)
