### PR TITLE
[refactor] import 경로 수정 

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,15 +1,18 @@
 module.exports = {
-  stories: ["../src/**/*.stories.(ts|tsx|js|jsx)"],
-  addons: [
-    "@storybook/preset-create-react-app",
-    "@storybook/addon-knobs/register",
-    "@storybook/addon-actions",
-    "@storybook/addon-links",
-    {
-      name: "@storybook/addon-docs",
-      options: {
-        configureJSX: true
-      }
-    }
-  ]
+    stories: ["../src/**/*.stories.(ts|tsx|js|jsx)"],
+    addons: [
+        "@storybook/preset-create-react-app",
+        "@storybook/addon-knobs/register",
+        "@storybook/addon-actions",
+        "@storybook/addon-links",
+        {
+            name: "@storybook/addon-docs",
+            options: {
+                configureJSX: true,
+            },
+        },
+    ],
+    webpackFinal: (config) => {
+        return require("../config-overrides")(config);
+    },
 };

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -1,0 +1,22 @@
+const tsconfigPaths = require("./tsconfig.paths.json")["compilerOptions"][
+    "paths"
+];
+
+const path = require("path");
+
+const alias = {};
+const resolve = (dir) => path.resolve(__dirname, dir);
+const removeSlashStar = (arg) => arg.split("/*")[0];
+
+Object.entries(tsconfigPaths).forEach(([key, [value]]) => {
+    const name = removeSlashStar(key);
+    const path = removeSlashStar(value);
+
+    alias[name] = resolve(path);
+});
+
+module.exports = function (config, env) {
+    config.resolve.alias = Object.assign(config.resolve.alias, alias);
+
+    return config;
+};

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
         "use-http": "^0.4.3"
     },
     "scripts": {
-        "start": "react-scripts start",
-        "build": "react-scripts build",
-        "test": "react-scripts test",
+        "start": "react-app-rewired start",
+        "build": "react-app-rewired build",
+        "test": "react-app-rewired test",
         "eject": "react-scripts eject",
         "storybook": "start-storybook -p 9009 -s public",
         "build-storybook": "build-storybook -s public"
@@ -57,6 +57,7 @@
         "@storybook/preset-create-react-app": "^2.0.0",
         "@storybook/react": "^5.3.17",
         "@types/storybook-react-router": "^1.0.1",
+        "react-app-rewired": "^2.1.5",
         "react-docgen-typescript-loader": "^3.7.1",
         "storybook-react-router": "^1.0.8"
     }

--- a/src/components/atoms/Button/style.scss
+++ b/src/components/atoms/Button/style.scss
@@ -1,4 +1,4 @@
-@import "../../../theme.scss";
+@import "~/theme.scss";
 
 button {
     height: 2.5rem;

--- a/src/components/atoms/SideNavigationItem/style.scss
+++ b/src/components/atoms/SideNavigationItem/style.scss
@@ -1,4 +1,4 @@
-@import "../../../theme.scss";
+@import "~/theme.scss";
 $sn-color: #58595b;
 $sn-dark-color: $base-dark-color;
 

--- a/src/components/molecules/PostTable/index.tsx
+++ b/src/components/molecules/PostTable/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import "./style.scss";
-import CommentCountIcon from "../../atoms/CommentCountIcon";
-import { displayDate } from "../../../utils";
+import CommentCountIcon from "@atoms/CommentCountIcon";
+import { displayDate } from "~/utils";
 
 const NOTICE_KO = "공지";
 const CLASSNAME_FOR_NOTICE = "notice";
@@ -69,7 +69,7 @@ const PostTable = (props: TableProps) => {
     return (
         <table>
             <tr>
-                {columns.map(col => (
+                {columns.map((col) => (
                     <th> {col} </th>
                 ))}
             </tr>
@@ -82,7 +82,7 @@ const PostTable = (props: TableProps) => {
 
 PostTable.defaultProps = {
     columns: ["번호", "제목", "", "날짜", "글쓴이", "조회수"],
-    posts: []
+    posts: [],
 };
 
 export default PostTable;

--- a/src/components/molecules/SideNavigation/index.stories.tsx
+++ b/src/components/molecules/SideNavigation/index.stories.tsx
@@ -1,12 +1,12 @@
 import React, { CSSProperties } from "react";
 import { withKnobs, text } from "@storybook/addon-knobs";
-import { SideNavigationItemProps } from "../../atoms/SideNavigationItem";
+import { SideNavigationItemProps } from "@atoms/SideNavigationItem";
 import SideNavigation from ".";
 
 export default {
     title: "Molecules / SideNavigation",
     component: SideNavigation,
-    decorators: [withKnobs]
+    decorators: [withKnobs],
 };
 
 const WrapperStyle: CSSProperties = {
@@ -15,22 +15,22 @@ const WrapperStyle: CSSProperties = {
     justifyContent: "center",
     alignItems: "center",
     padding: "5rem",
-    height: "80vh"
+    height: "80vh",
 };
 
 export const index = () => {
     const items: SideNavigationItemProps[] = [
         {
             itemId: "#회의록",
-            name: text("item1-name", "회의록")
+            name: text("item1-name", "회의록"),
         },
         {
             itemId: "#스터디",
-            name: text("item2-name", "스터디")
+            name: text("item2-name", "스터디"),
         },
         {
             itemId: "#문서",
-            name: text("item3-name", "문서")
+            name: text("item3-name", "문서"),
         },
         {
             itemId: "#기출문서",
@@ -38,13 +38,13 @@ export const index = () => {
             subItems: [
                 { itemId: "#2019", name: "2019" },
                 { itemId: "#2018", name: "2018" },
-                { itemId: "#2017", name: "2017" }
-            ]
+                { itemId: "#2017", name: "2017" },
+            ],
         },
         {
             itemId: "#프로젝트",
-            name: text("item5-name", "프로젝트")
-        }
+            name: text("item5-name", "프로젝트"),
+        },
     ];
     return (
         <div style={WrapperStyle}>

--- a/src/components/molecules/SideNavigation/index.tsx
+++ b/src/components/molecules/SideNavigation/index.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState, SyntheticEvent } from "react";
 import SideNavigationItem, {
-    SideNavigationItemProps
-} from "../../atoms/SideNavigationItem";
+    SideNavigationItemProps,
+} from "@atoms/SideNavigationItem";
 import "./style.scss";
 
 interface SideNavigationProps {

--- a/src/components/organisms/Header/index.tsx
+++ b/src/components/organisms/Header/index.tsx
@@ -1,17 +1,17 @@
 import React, { useState } from "react";
 import { Link, useHistory } from "react-router-dom";
-import Button from "../../atoms/Button";
-import Dropdown, { DropdownItem } from "../../molecules/Dropdown";
+import Button from "@atoms/Button";
+import Dropdown, { DropdownItem } from "@molecules/Dropdown";
 import logo from "./logo.jpg";
 import "./style.scss";
 
-import { login } from "../../../apis/Auth";
-import { useAuth, Action } from "../../../contexts/Auth";
+import { login } from "~/apis/Auth";
+import { useAuth, Action } from "~/contexts/Auth";
 
 const Header = () => {
     const {
         state: { user },
-        dispatch: userDispatch
+        dispatch: userDispatch,
     } = useAuth();
 
     const [dropdownOpen, setDropdownOpen] = useState(false);
@@ -20,17 +20,17 @@ const Header = () => {
     const items: DropdownItem[] = [
         {
             name: "마이페이지",
-            onClick: () => history.push("/mypage")
+            onClick: () => history.push("/mypage"),
         },
         {
             name: "로그아웃",
             onClick: () => {
                 userDispatch({
-                    type: Action.LOGOUT
+                    type: Action.LOGOUT,
                 });
                 history.push("/");
-            }
-        }
+            },
+        },
     ];
 
     const handleClickOpenDropDown = () => {
@@ -57,7 +57,7 @@ const Header = () => {
                 </ul>
             </nav>
             <div className="login_status_wrapper">
-                {user && user.username ? (
+                {user ? (
                     <>
                         <div className="tri"></div> &nbsp;
                         <b

--- a/src/components/organisms/Header/style.scss
+++ b/src/components/organisms/Header/style.scss
@@ -1,4 +1,4 @@
-@import "../../../theme.scss";
+@import "~/theme.scss";
 
 header {
     display: flex;

--- a/src/components/organisms/SignUpForm/index.tsx
+++ b/src/components/organisms/SignUpForm/index.tsx
@@ -1,7 +1,7 @@
 import React, { FormHTMLAttributes } from "react";
-import Button from "../../atoms/Button";
-import FormInput from "../../molecules/FormInput";
-import FormSelect from "../../molecules/FormSelect";
+import Button from "@atoms/Button";
+import FormInput from "@molecules/FormInput";
+import FormSelect from "@molecules/FormSelect";
 import "./style.scss";
 
 interface SignUpFormProps extends FormHTMLAttributes<HTMLFormElement> {
@@ -37,7 +37,7 @@ function SignUpForm(props: SignUpFormProps) {
                         { value: "졸업" },
                         { value: "휴학 예정" },
                         { value: "졸업 예정" },
-                        { value: "재학 예정" }
+                        { value: "재학 예정" },
                     ]}
                     required={true}
                     invalid={isValid.schoolRegister}

--- a/src/contexts/Auth/context.tsx
+++ b/src/contexts/Auth/context.tsx
@@ -1,14 +1,14 @@
 import React, { createContext, useReducer, useEffect, useContext } from "react";
 import { useCookies } from "react-cookie";
 import { authReducer, initialState, AuthAction, AuthState } from "./reducer";
-import { getLocalStorage } from "../../utils";
+import { getLocalStorage } from "~/utils";
 import {
     TOKEN_KEY,
     setToken,
     isTokenValid,
-    getTokenValues
-} from "../../apis/utils";
-import { logout } from "../../apis/Auth";
+    getTokenValues,
+} from "~/apis/utils";
+import { logout } from "~/apis/Auth";
 import Action from "./actions";
 
 type AuthContextProps = {
@@ -18,7 +18,7 @@ type AuthContextProps = {
 
 const AuthContext = createContext<AuthContextProps>({
     state: initialState,
-    dispatch: () => initialState
+    dispatch: () => initialState,
 });
 
 export function AuthProvider(props: React.PropsWithChildren<{}>) {

--- a/src/contexts/Auth/reducer.tsx
+++ b/src/contexts/Auth/reducer.tsx
@@ -1,4 +1,4 @@
-import { User } from "../../types";
+import { User } from "~/types";
 import Action from "./actions";
 
 export type AuthAction =
@@ -13,7 +13,7 @@ export interface AuthState {
 
 export const initialState: AuthState = {
     isAuthenticated: false,
-    user: null
+    user: null,
 };
 
 export function authReducer(state: AuthState, action: AuthAction): AuthState {

--- a/src/index.scss
+++ b/src/index.scss
@@ -39,7 +39,7 @@ main {
     justify-content: center;
     align-items: center;
     padding: 5rem;
-    height: 80vh;
+    height: auto;
 }
 
 @media all and(max-width: 768px) {
@@ -50,6 +50,14 @@ main {
 
 button {
     cursor: pointer;
+}
+
+select {
+    -webkit-appearance: inherit;
+    background: url("./components/molecules/FormSelect/downarrow.png") no-repeat
+        95% 50%;
+    background-size: 1rem;
+    border-radius: 0;
 }
 
 ul {

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Header from "../../components/organisms/Header";
+import Header from "@organisms/Header";
 
 const Home = () => (
     <>

--- a/src/pages/SignUp/index.tsx
+++ b/src/pages/SignUp/index.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import SignUpForm from "../../components/organisms/SignUpForm";
+import SignUpForm from "@organisms/SignUpForm";
 import useSignUp, { SignUpProvider, Action } from "./store";
 import "./style.scss";
 
@@ -23,7 +23,7 @@ const SignUpView = () => {
         const { name, value } = e.target;
         signUpDispatch({
             type: Action.UPDATE_INFO,
-            inputValue: { name, value }
+            inputValue: { name, value },
         });
     };
 

--- a/src/pages/SignUp/store.tsx
+++ b/src/pages/SignUp/store.tsx
@@ -1,16 +1,16 @@
 import React, { createContext, useReducer, useEffect, useContext } from "react";
 import { useHistory } from "react-router-dom";
 import { useCookies } from "react-cookie";
-import { getTokenValues, setToken } from "../../apis/utils";
-import { useAuth, Action as authAction } from "../../contexts/Auth";
-import { signUp } from "../../apis/Auth";
-import { Profile } from "../../types";
+import { getTokenValues, setToken } from "~/apis/utils";
+import { signUp } from "~/apis/Auth";
+import { useAuth, Action as authAction } from "~/contexts/Auth";
+import { Profile } from "~/types";
 import validator from "./validate";
 
 export enum Action {
     UPDATE_INFO = "UPDATE_INFO",
     SUBMIT = "SUBMIT",
-    LOAD_USER = "LOAD_USER"
+    LOAD_USER = "LOAD_USER",
 }
 
 interface ValidateStateType {
@@ -47,10 +47,10 @@ export const initialState: SignUpState = {
         birth: undefined,
         username: undefined,
         email: undefined,
-        blog: undefined
+        blog: undefined,
     },
     user: null,
-    submit: "before"
+    submit: "before",
 };
 
 export function SignUpReducer(
@@ -66,8 +66,8 @@ export function SignUpReducer(
                     id: user?.id,
                     email: user?.email,
                     blog: user?.blog,
-                    username: user?.username
-                }
+                    username: user?.username,
+                },
             };
         }
 
@@ -81,12 +81,12 @@ export function SignUpReducer(
                 ...state,
                 user: {
                     ...user,
-                    [name]: value
+                    [name]: value,
                 },
                 validateState: {
                     ...validateState,
-                    [name]: result
-                }
+                    [name]: result,
+                },
             };
         }
         case Action.SUBMIT: {
@@ -105,7 +105,7 @@ type SignUpContextProps = {
 
 const SignUpContext = createContext<SignUpContextProps>({
     state: initialState,
-    dispatch: () => initialState
+    dispatch: () => initialState,
 });
 
 export function SignUpProvider(props: React.PropsWithChildren<{}>) {
@@ -123,7 +123,7 @@ export function SignUpProvider(props: React.PropsWithChildren<{}>) {
         //@TODO: load 후 validate, exist 시 '/' 리다이렉트
         dispatch({
             type: Action.LOAD_USER,
-            user: { id, username, blog, email }
+            user: { id, username, blog, email },
         });
     }, []);
 
@@ -134,13 +134,13 @@ export function SignUpProvider(props: React.PropsWithChildren<{}>) {
             const user = await signUp(state.user);
             authDispath({
                 type: authAction.LOAD_USER,
-                payload: user
+                payload: user,
             });
             history.replace("/");
         } catch (err) {
             dispatch({
                 type: Action.SUBMIT,
-                payload: false
+                payload: false,
             });
             console.error(err);
             //@TODO: 에러 모달 띄우기

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,1 +1,2 @@
 export { default as Home } from "./Home";
+export { default as SignUp } from "./SignUp";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./tsconfig.paths.json",
   "compilerOptions": {
     "target": "es5",
     "lib": [

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+            "~/*": ["./src/*"],
+            "@atoms/*": ["./src/components/atoms/*"],
+            "@molecules/*": ["./src/components/molecules/*"],
+            "@organisms/*": ["./src/components/organisms/*"]
+        }
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11425,6 +11425,13 @@ react-app-polyfill@^1.0.6:
     regenerator-runtime "^0.13.3"
     whatwg-fetch "^3.0.0"
 
+react-app-rewired@^2.1.5:
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/react-app-rewired/-/react-app-rewired-2.1.5.tgz#592ec2eae5c3c5cd96c80930b5dc3f6c34da1dc6"
+  integrity sha512-Gr8KfCeL9/PTQs8Vvxc7v8wQ9vCFMnYPhcAkrMlzkLiMFXS+BgSwm11MoERjZm7dpA2WjTi+Pvbu/w7rujAV+A==
+  dependencies:
+    semver "^5.6.0"
+
 react-clientside-effect@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz#6212fb0e07b204e714581dd51992603d1accc837"


### PR DESCRIPTION
---
```js
import Button '../../components/atoms/Button';
```
```js
import Button '@atoms/Button';
```

프로젝트를 진행하면서  `import 경로`가 길어졌다. 
소스 코드를 깔끔하게 유지하고 싶어 더 늦기 전에, `alias` 설정을 하기로 결심했다. 

react-app-rewired 모듈을 사용하여 CRA의 webpack 에 alias 설정을 추가하고, 
프로젝트의 Import 경로를 수정


## 참고
[CRA + TypeScript + Storybook absolute Path 설정](https://github.com/lallaheeee/error-note/issues/1)
