### PR TITLE
[게시판] 카테고리를 클릭하면 해당 카테고리의 게시글이 노출 

### DIFF
--- a/src/apis/Article.ts
+++ b/src/apis/Article.ts
@@ -1,5 +1,5 @@
 import API from "./utils";
-import { Article as IArticle, Category, ArticleInfo } from "~/types";
+import { Article as IArticle, ArticleInfo } from "~/types";
 
 type ArticleList = {
     articles: ArticleInfo[];
@@ -14,13 +14,13 @@ function limit(count: number, p: number = 0) {
     return `limit=${count}&offset=${p * count}`;
 }
 
-function categoryQuery(category?: string | Category) {
+function categoryQuery(category?: number) {
     if (!category) return "";
-    const name = typeof category === "string" ? category : category.name;
-    return `category=${name}`;
+
+    return `category=${category}`;
 }
 
-export function getArticles(page: number, category?: string | Category) {
+export function getArticles(page: number, category?: number) {
     const query = categoryQuery(category);
 
     return API.get<ArticleList>(

--- a/src/apis/Category.ts
+++ b/src/apis/Category.ts
@@ -7,10 +7,13 @@ type Category = {
 
 function addLink(categories: ICategory[]): ICategory[] {
     return categories.map(category => {
-        if (!category.subItems)
-            return { ...category, to: `/articles?category=${category.id}` };
-
-        return { ...category, subItems: addLink(category.subItems) };
+        return !category.subItems
+            ? { ...category, to: `/articles?category=${category.id}` }
+            : {
+                  ...category,
+                  to: `/articles?category=${category.id}`,
+                  subItems: addLink(category.subItems),
+              };
     });
 }
 

--- a/src/components/atoms/SideNavigationItem/index.tsx
+++ b/src/components/atoms/SideNavigationItem/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, SyntheticEvent } from "react";
+import React, { SyntheticEvent } from "react";
 import StyledLink from "@atoms/StyledLink";
 import "./style.scss";
 
@@ -25,6 +25,10 @@ export interface SideNavigationItemProps {
      */
     subItems?: SideNavigationItemProps[];
     /**
+     * 자식의 클릭된 상태
+     */
+    childActive?: string;
+    /**
      * 이벤트 핸들러
      */
     onClick?: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
@@ -35,7 +39,7 @@ export interface SideNavigationSubItemsProps {
     parentId: number | string;
     activeItemId: number | string;
     items: SideNavigationItemProps[];
-    onClick: (e: SyntheticEvent<HTMLElement>) => void;
+    onClick?: (e: SyntheticEvent<HTMLElement>) => void;
 }
 
 const SideNavigationSubItems = ({
@@ -64,61 +68,32 @@ export const SideNavigationItem = (props: SideNavigationItemProps) => {
     const {
         name,
         to,
-        onClick,
         active = false,
         children = "",
         id,
         subItems = [],
+        childActive,
         className = "",
     } = props;
-    const [currentItemId, setActiveItemId] = useState<number | string>(
-        subItems.length ? subItems[0].id : ""
-    );
-
-    const handleClick = (e: SyntheticEvent<HTMLElement>) => {
-        if (subItems.length) setActiveItemId(subItems[0].id);
-        if (!(e.target instanceof HTMLElement && e.target.dataset)) return;
-
-        const datasetId = e.target.dataset.itemId;
-        if (!datasetId) return;
-
-        if (datasetId.startsWith(`${id}-`)) {
-            setActiveItemId(datasetId.split("-")[1]);
-        }
-    };
 
     return (
         <>
-            {!!subItems.length ? (
+            <StyledLink to={to}>
                 <div
                     data-item-id={id}
-                    onClick={onClick}
                     className={`side_navigation_item ${
                         active ? "active" : ""
                     } ${className}`}
                 >
                     {children || name}
-                    {active && (
-                        <SideNavigationSubItems
-                            parentId={id}
-                            activeItemId={currentItemId}
-                            onClick={handleClick}
-                            items={subItems}
-                        />
-                    )}
                 </div>
-            ) : (
-                <StyledLink to={to}>
-                    <div
-                        data-item-id={id}
-                        onClick={onClick}
-                        className={`side_navigation_item ${
-                            active ? "active" : ""
-                        } ${className}`}
-                    >
-                        {children || name}
-                    </div>
-                </StyledLink>
+            </StyledLink>
+            {active && !!subItems.length && (
+                <SideNavigationSubItems
+                    parentId={id}
+                    activeItemId={childActive || ""}
+                    items={subItems}
+                />
             )}
         </>
     );

--- a/src/components/molecules/SideNavigation/index.tsx
+++ b/src/components/molecules/SideNavigation/index.tsx
@@ -21,15 +21,18 @@ const SideNavigation = (props: SideNavigationProps) => {
     const [currentItemId, setActiveItemId] = useState(
         activeItemId || items[0]?.id
     );
+    const [childActiveId, setChildActiveId] = useState("");
+
     const handleClick = (e: SyntheticEvent<HTMLElement>) => {
         if (!(e.target instanceof HTMLElement && e.target.dataset)) return;
 
         const datasetId = e.target.dataset.itemId;
         if (!datasetId) return;
 
-        const clickedItemId = datasetId.split("-")[0];
+        const [parent, child] = datasetId.split("-");
 
-        setActiveItemId(clickedItemId);
+        setActiveItemId(parent);
+        setChildActiveId(child);
     };
 
     const SideNavigationItems = useMemo(
@@ -39,10 +42,11 @@ const SideNavigation = (props: SideNavigationProps) => {
                     data-item-id={item.id}
                     key={item.id}
                     active={currentItemId === item.id.toString()}
+                    childActive={childActiveId}
                     {...item}
                 />
             )),
-        [items, currentItemId]
+        [items, currentItemId, childActiveId]
     );
 
     if (!items.length) return null;

--- a/src/contexts/ArticleList/context.tsx
+++ b/src/contexts/ArticleList/context.tsx
@@ -25,7 +25,7 @@ export function ArticleListProvider(props: React.PropsWithChildren<{}>) {
         initialState
     );
     const {
-        state: { categories, selectedTab },
+        state: { selectedTab },
     } = useCategory();
 
     const fetchArticleList = () => {
@@ -33,12 +33,7 @@ export function ArticleListProvider(props: React.PropsWithChildren<{}>) {
             type: Action.FETCH_ARTICLIES_LOADING,
         });
 
-        const { page } = state;
-        const selectedCategory = categories.find(
-            category => category.id === selectedTab
-        )?.name;
-
-        api.getArticles(page, selectedCategory)
+        api.getArticles(state.page, selectedTab)
             .then(payload =>
                 ArticleListDispatch({
                     type: Action.FETCH_ARTICLIES_SUCCESS,

--- a/src/pages/ArticleList/index.tsx
+++ b/src/pages/ArticleList/index.tsx
@@ -5,11 +5,11 @@ import View from "./view";
 
 const ArticleList = () => {
     return (
-        <ArticleListProvider>
-            <CategoryProvider>
+        <CategoryProvider>
+            <ArticleListProvider>
                 <View />
-            </CategoryProvider>
-        </ArticleListProvider>
+            </ArticleListProvider>
+        </CategoryProvider>
     );
 };
 


### PR DESCRIPTION
## Description

1.스토어 순서 변경 
articlelist에서 category를 사용하기 때문에 순서  변경

2. 카테고리 리퀘스트 쿼리 변경
 이름이 똑같은 카테고리가 있을 수 있기 때문에 
기존의 ?category=name에서 ?category=id 로 변경

3. sideNavigation 리팩토링 
이벤트 핸들러를 줄임
기존의 부모 카테고리를 클릭하면 자식의 카테고리만을 선택할 수 있었는데 
부모의 카테고리도 선택가능하도록 변경